### PR TITLE
Move archived packages to Archive section, add build artifacts

### DIFF
--- a/.github/workflows/rebuild_docs.yml
+++ b/.github/workflows/rebuild_docs.yml
@@ -19,6 +19,12 @@ jobs:
         run: julia --project=docs -e 'using Pkg; Pkg.instantiate()'
       - name: Build documentation
         run: julia --project=docs docs/make.jl
+      - name: Upload documentation artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: multidocs-build
+          path: docs/out/
+          retention-days: 7
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,3 +28,9 @@ jobs:
         run: julia --project=docs -e 'using Pkg; Pkg.instantiate()'
       - name: Build documentation
         run: julia --project=docs docs/make.jl
+      - name: Upload documentation artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: multidocs-build
+          path: docs/out/
+          retention-days: 7

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -36,27 +36,10 @@ docs = [
         giturl = "https://github.com/harmoniqs/Piccolo.jl.git",
     ),
     MultiDocumenter.MultiDocRef(
-        upstream = joinpath(clonedir, "PiccoloQuantumObjects"),
-        path = "PiccoloQuantumObjects",
-        name = "Quantum Objects",
-        giturl = "https://github.com/harmoniqs/PiccoloQuantumObjects.jl.git",
-    ),
-    MultiDocumenter.DropdownNav(
-        "Optimal Controls",
-        [
-            MultiDocumenter.MultiDocRef(
-                upstream = joinpath(clonedir, "QuantumCollocation"),
-                path = "QuantumCollocation",
-                name = "QuantumCollocation.jl",
-                giturl = "https://github.com/harmoniqs/QuantumCollocation.jl.git",
-            ),
-            MultiDocumenter.MultiDocRef(
-                upstream = joinpath(clonedir, "DirectTrajOpt"),
-                path = "DirectTrajOpt",
-                name = "DirectTrajOpt.jl",
-                giturl = "https://github.com/harmoniqs/DirectTrajOpt.jl.git",
-            ),
-        ],
+        upstream = joinpath(clonedir, "DirectTrajOpt"),
+        path = "DirectTrajOpt",
+        name = "DirectTrajOpt.jl",
+        giturl = "https://github.com/harmoniqs/DirectTrajOpt.jl.git",
     ),
     MultiDocumenter.DropdownNav(
         "Trajectories",
@@ -75,23 +58,34 @@ docs = [
             ),
         ],
     ),
-    MultiDocumenter.MultiDocRef(
-        upstream = joinpath(clonedir, "PiccoloPlots"),
-        path = "PiccoloPlots",
-        name = "Plots",
-        giturl = "https://github.com/harmoniqs/PiccoloPlots.jl.git",
-    ),
-
     MultiDocumenter.DropdownNav(
         "Archive",
         [
+            MultiDocumenter.MultiDocRef(
+                upstream = joinpath(clonedir, "PiccoloQuantumObjects"),
+                path = "PiccoloQuantumObjects",
+                name = "PiccoloQuantumObjects.jl",
+                giturl = "https://github.com/harmoniqs/PiccoloQuantumObjects.jl.git",
+            ),
+            MultiDocumenter.MultiDocRef(
+                upstream = joinpath(clonedir, "QuantumCollocation"),
+                path = "QuantumCollocation",
+                name = "QuantumCollocation.jl",
+                giturl = "https://github.com/harmoniqs/QuantumCollocation.jl.git",
+            ),
+            MultiDocumenter.MultiDocRef(
+                upstream = joinpath(clonedir, "PiccoloPlots"),
+                path = "PiccoloPlots",
+                name = "PiccoloPlots.jl",
+                giturl = "https://github.com/harmoniqs/PiccoloPlots.jl.git",
+            ),
             MultiDocumenter.MultiDocRef(
                 upstream = joinpath(clonedir, "QuantumCollocationCore"),
                 path = "QuantumCollocationCore",
                 name = "QuantumCollocationCore.jl",
                 giturl = "https://github.com/harmoniqs/QuantumCollocationCore.jl.git",
             ),
-        ]
+        ],
     ),
 ]
 


### PR DESCRIPTION
## Summary
- Move PiccoloQuantumObjects.jl, QuantumCollocation.jl, and PiccoloPlots.jl to the Archive dropdown in the multidocs nav
- Promote DirectTrajOpt.jl to a top-level nav entry (was under "Optimal Controls" dropdown)
- Add `upload-artifact` steps to both the Aggregate (`test.yml`) and Rebuild Docs (`rebuild_docs.yml`) workflows for review and debugging

## Test plan
- [ ] Verify the Aggregate CI workflow passes and produces a documentation artifact
- [ ] Review the artifact to confirm nav structure: Piccolo, DirectTrajOpt.jl, Trajectories dropdown, Archive dropdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)