### PR TITLE
chore(ci): add Dependabot config for Julia + Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "julia"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary
- Adds new `.github/dependabot.yml` configuring both `julia` and `github-actions` ecosystems on a weekly schedule.

## Why
Aligns with the org-wide migration to Dependabot for dependency updates. Dependabot now natively supports the `julia` ecosystem, and `dependabot[bot]` PRs trigger CI (unlike CompatHelper's `github-actions[bot]` PRs). Supports `ignore` directives for noisy bumps.

## Test plan
- [ ] Within a week, expect a `dependabot[bot]` PR for Julia or Actions; confirm CI runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)