### PR TITLE
Add Legato + Intonato to docs hub; normalize nav labels to slugs

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -38,8 +38,20 @@ docs = [
     MultiDocumenter.MultiDocRef(
         upstream = joinpath(clonedir, "DirectTrajOpt"),
         path = "DirectTrajOpt",
-        name = "DirectTrajOpt.jl",
+        name = "DirectTrajOpt",
         giturl = "https://github.com/harmoniqs/DirectTrajOpt.jl.git",
+    ),
+    MultiDocumenter.MultiDocRef(
+        upstream = joinpath(clonedir, "Legato"),
+        path = "Legato",
+        name = "Legato",
+        giturl = "https://github.com/harmoniqs/Legato.jl.git",
+    ),
+    MultiDocumenter.MultiDocRef(
+        upstream = joinpath(clonedir, "Intonato"),
+        path = "Intonato",
+        name = "Intonato",
+        giturl = "https://github.com/harmoniqs/Intonato.jl.git",
     ),
     MultiDocumenter.DropdownNav(
         "Trajectories",
@@ -47,13 +59,13 @@ docs = [
             MultiDocumenter.MultiDocRef(
                 upstream = joinpath(clonedir, "NamedTrajectories"),
                 path = "NamedTrajectories",
-                name = "NamedTrajectories.jl",
+                name = "NamedTrajectories",
                 giturl = "https://github.com/harmoniqs/NamedTrajectories.jl.git",
             ),
             MultiDocumenter.MultiDocRef(
                 upstream = joinpath(clonedir, "TrajectoryIndexingUtils"),
                 path = "TrajectoryIndexingUtils",
-                name = "TrajectoryIndexingUtils.jl",
+                name = "TrajectoryIndexingUtils",
                 giturl = "https://github.com/harmoniqs/TrajectoryIndexingUtils.jl.git",
             ),
         ],
@@ -64,25 +76,25 @@ docs = [
             MultiDocumenter.MultiDocRef(
                 upstream = joinpath(clonedir, "PiccoloQuantumObjects"),
                 path = "PiccoloQuantumObjects",
-                name = "PiccoloQuantumObjects.jl",
+                name = "PiccoloQuantumObjects",
                 giturl = "https://github.com/harmoniqs/PiccoloQuantumObjects.jl.git",
             ),
             MultiDocumenter.MultiDocRef(
                 upstream = joinpath(clonedir, "QuantumCollocation"),
                 path = "QuantumCollocation",
-                name = "QuantumCollocation.jl",
+                name = "QuantumCollocation",
                 giturl = "https://github.com/harmoniqs/QuantumCollocation.jl.git",
             ),
             MultiDocumenter.MultiDocRef(
                 upstream = joinpath(clonedir, "PiccoloPlots"),
                 path = "PiccoloPlots",
-                name = "PiccoloPlots.jl",
+                name = "PiccoloPlots",
                 giturl = "https://github.com/harmoniqs/PiccoloPlots.jl.git",
             ),
             MultiDocumenter.MultiDocRef(
                 upstream = joinpath(clonedir, "QuantumCollocationCore"),
                 path = "QuantumCollocationCore",
-                name = "QuantumCollocationCore.jl",
+                name = "QuantumCollocationCore",
                 giturl = "https://github.com/harmoniqs/QuantumCollocationCore.jl.git",
             ),
         ],


### PR DESCRIPTION
## Add Legato + Intonato to the docs hub; normalize nav labels to slugs

Adds the two newly-standardized packages to the aggregate docs site and tidies the nav.

### Changes (`docs/make.jl`)
- **Legato** and **Intonato** added as top-level `MultiDocRef`s (after DirectTrajOpt), pulled from their `gh-pages` like every other package.
- **Nav display names normalized to bare slugs** (drop `.jl`) for every entry, matching the existing `Piccolo` style: `DirectTrajOpt`, `Legato`, `Intonato`, `NamedTrajectories`, `TrajectoryIndexingUtils`, `PiccoloQuantumObjects`, `QuantumCollocation`, `PiccoloPlots`, `QuantumCollocationCore`. URL `path`s are unchanged.

### Validation
Built the aggregate locally (`julia --project=docs docs/make.jl`) — `MAKE=0`, all 10 packages render, nav shows slugs, Legato/Intonato pages present.

### Note for deploy
Production aggregation clones each package's `gh-pages`. Intonato's now exists; **Legato's `gh-pages` is still stale (serves "Stretto")** until its docs are re-deployed — handled separately by pushing a `v0.5.0+docs` tag on Legato.
